### PR TITLE
implementing basic routing

### DIFF
--- a/SavingMoney.xcodeproj/project.pbxproj
+++ b/SavingMoney.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		631E1A762771BD79000C2DD1 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E1A752771BD79000C2DD1 /* AppCoordinatorTests.swift */; };
+		631E1A7827731015000C2DD1 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E1A7727731015000C2DD1 /* AppCoordinator.swift */; };
+		631E1A7A2773105E000C2DD1 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E1A792773105E000C2DD1 /* Coordinator.swift */; };
 		6325D4D327707D1F00D5038C /* SavingPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6325D4D227707D1F00D5038C /* SavingPlan.swift */; };
 		635BEA532769BB6700D300E0 /* KeyboardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BEA522769BB6700D300E0 /* KeyboardController.swift */; };
 		635BEA552769BB8C00D300E0 /* KeyboardEventViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BEA542769BB8C00D300E0 /* KeyboardEventViewModel.swift */; };
@@ -54,6 +56,8 @@
 
 /* Begin PBXFileReference section */
 		631E1A752771BD79000C2DD1 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
+		631E1A7727731015000C2DD1 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		631E1A792773105E000C2DD1 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		6325D4D227707D1F00D5038C /* SavingPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavingPlan.swift; sourceTree = "<group>"; };
 		635BEA522769BB6700D300E0 /* KeyboardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardController.swift; sourceTree = "<group>"; };
 		635BEA542769BB8C00D300E0 /* KeyboardEventViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardEventViewModel.swift; sourceTree = "<group>"; };
@@ -252,6 +256,8 @@
 			children = (
 				63CEF5242765B00C0038E36E /* AppDelegate.swift */,
 				63CEF5262765B00C0038E36E /* SceneDelegate.swift */,
+				631E1A7727731015000C2DD1 /* AppCoordinator.swift */,
+				631E1A792773105E000C2DD1 /* Coordinator.swift */,
 				638B80B1276CC64B00FE618A /* Composers */,
 				639F016B27679E9B00007110 /* Shared */,
 				639F017227679F3200007110 /* WritePlan */,
@@ -382,11 +388,13 @@
 			files = (
 				639F016F27679EE900007110 /* PlanModel.swift in Sources */,
 				638B9EB527709BFD004AC952 /* SavingCellController.swift in Sources */,
+				631E1A7827731015000C2DD1 /* AppCoordinator.swift in Sources */,
 				63CEF5292765B00C0038E36E /* WriteDownPlanViewController.swift in Sources */,
 				6325D4D327707D1F00D5038C /* SavingPlan.swift in Sources */,
 				639F016A27679E7600007110 /* UITextField+Helpers.swift in Sources */,
 				63CEF5252765B00C0038E36E /* AppDelegate.swift in Sources */,
 				635BEA532769BB6700D300E0 /* KeyboardController.swift in Sources */,
+				631E1A7A2773105E000C2DD1 /* Coordinator.swift in Sources */,
 				638B80B3276DDD7F00FE618A /* ProgressionViewModel.swift in Sources */,
 				635BEA65276A19E100D300E0 /* BinaryInteger+digits.swift in Sources */,
 				639F016527661D6900007110 /* SavingCell.swift in Sources */,

--- a/SavingMoney.xcodeproj/project.pbxproj
+++ b/SavingMoney.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		631E1A762771BD79000C2DD1 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631E1A752771BD79000C2DD1 /* AppCoordinatorTests.swift */; };
 		6325D4D327707D1F00D5038C /* SavingPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6325D4D227707D1F00D5038C /* SavingPlan.swift */; };
 		635BEA532769BB6700D300E0 /* KeyboardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BEA522769BB6700D300E0 /* KeyboardController.swift */; };
 		635BEA552769BB8C00D300E0 /* KeyboardEventViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635BEA542769BB8C00D300E0 /* KeyboardEventViewModel.swift */; };
@@ -52,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		631E1A752771BD79000C2DD1 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		6325D4D227707D1F00D5038C /* SavingPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavingPlan.swift; sourceTree = "<group>"; };
 		635BEA522769BB6700D300E0 /* KeyboardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardController.swift; sourceTree = "<group>"; };
 		635BEA542769BB8C00D300E0 /* KeyboardEventViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardEventViewModel.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 				63CEF53E2765B07C0038E36E /* WriteDownPlanViewControllerTests.swift */,
 				635BEA582769D15900D300E0 /* SetAmountViewControllerTests.swift */,
 				638B80AD276CC43200FE618A /* SavingMoneyViewControllerTests.swift */,
+				631E1A752771BD79000C2DD1 /* AppCoordinatorTests.swift */,
 			);
 			path = SavingMoneyTests;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				631E1A762771BD79000C2DD1 /* AppCoordinatorTests.swift in Sources */,
 				63CEF53F2765B07C0038E36E /* WriteDownPlanViewControllerTests.swift in Sources */,
 				638B80AE276CC43200FE618A /* SavingMoneyViewControllerTests.swift in Sources */,
 				635BEA572769C88A00D300E0 /* SceneDelegateTests.swift in Sources */,

--- a/SavingMoney/AppCoordinator.swift
+++ b/SavingMoney/AppCoordinator.swift
@@ -1,0 +1,65 @@
+//
+//  AppCoordinator.swift
+//  SavingMoney
+//
+//  Created by Paul Lee on 2021/12/22.
+//
+
+import Foundation
+import UIKit
+
+class AppCoordinator: Coordinator {
+    var router: UIViewController {
+        return navc
+    }
+    
+    private let navc: UINavigationController
+    
+    init(router: UINavigationController) {
+        self.navc = router
+    }
+    
+    private var savingPlan = SavingPlan(name: "", initialAmount: 0)
+    
+    private lazy var writeDownPlanViewModel: WriteDownPlanViewModel =
+    WriteDownPlanViewModel(
+        onNext: { [unowned self] planName in
+            savingPlan.name = planName
+            pushToSetAmountScene()
+        }
+    )
+    
+    func start() {
+        let vc = WriteDownPlanUIComposer
+            .compose(viewModel: writeDownPlanViewModel)
+
+        navc.setViewControllers([vc], animated: false)
+    }
+    
+    private func pushToSetAmountScene() {
+        let vc = SetAmountUIComposer
+            .compose(onNext: { [unowned self] planAmount in
+                savingPlan.initialAmount = planAmount.initialAmount
+                pushToSavingScene()
+            })
+        
+        navc.pushViewController(vc, animated: true)
+    }
+    
+    private func pushToSavingScene() {
+        let vc = SavingUIComposer
+            .compose(model: savingPlan, onNext: { [unowned self] in
+                backToWriteDownPlanScene()
+            })
+        
+        vc.modalPresentationStyle = .fullScreen
+        navc.present(vc, animated: true, completion: nil)
+    }
+    
+    private func backToWriteDownPlanScene() {
+        writeDownPlanViewModel.reset()
+        navc.dismiss(animated: true) { [navc] in
+            navc.popToRootViewController(animated: true)
+        }
+    }
+}

--- a/SavingMoney/Base.lproj/Main.storyboard
+++ b/SavingMoney/Base.lproj/Main.storyboard
@@ -326,7 +326,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="設定金額" id="gak-ck-Wnp">
-                        <barButtonItem key="rightBarButtonItem" title="開始" id="MS2-B8-7yK"/>
+                        <barButtonItem key="rightBarButtonItem" title="開始" id="MS2-B8-7yK">
+                            <connections>
+                                <action selector="nextBarBtnTapped:" destination="ilb-C4-z6D" id="p21-zV-TWO"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="deleteBtn" destination="O2j-qH-YCg" id="UgP-SJ-E6u"/>

--- a/SavingMoney/Composers/WriteDownPlanUIComposer.swift
+++ b/SavingMoney/Composers/WriteDownPlanUIComposer.swift
@@ -8,15 +8,16 @@
 import UIKit
 
 public class WriteDownPlanUIComposer {
-    public static func compose(onNext: @escaping (PlanModel) -> Void) -> WriteDownPlanViewController {
+    public static func compose(
+        viewModel: WriteDownPlanViewModel
+    ) -> WriteDownPlanViewController {
         let keyboardController = KeyboardController(viewModel: KeyboardEventViewModel())
         
         let vc = UIStoryboard(name: "Main", bundle: Bundle(for: WriteDownPlanViewController.self)).instantiateViewController(identifier: "WriteDownPlanViewController", creator: { coder in
             return WriteDownPlanViewController(
                 coder: coder,
-                viewModel: WriteDownPlanViewModel(
-                    onNext: onNext
-                ), keyboardController: keyboardController
+                viewModel: viewModel,
+                keyboardController: keyboardController
             )
         })
         

--- a/SavingMoney/Coordinator.swift
+++ b/SavingMoney/Coordinator.swift
@@ -1,0 +1,14 @@
+//
+//  Coordinator.swift
+//  SavingMoney
+//
+//  Created by Paul Lee on 2021/12/22.
+//
+
+import Foundation
+import UIKit
+
+protocol Coordinator {
+    var router: UIViewController { get }
+    func start()
+}

--- a/SavingMoney/Saving/SavingPlan.swift
+++ b/SavingMoney/Saving/SavingPlan.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 public struct SavingPlan {
-    public let name: String
+    public var name: String
     
     public let startDate: Date
     
-    public let initialAmount: Int
+    public var initialAmount: Int
     
     public var totalAmount: Int {
         initialAmount*(52)*(52+1)/2

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -51,7 +51,7 @@ class AppCoordinator: Coordinator {
                 
             })
         
-        navc.pushViewController(vc, animated: true)
+        navc.present(vc, animated: true, completion: nil)
     }
 }
 

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -7,10 +7,28 @@
 
 import UIKit
 
+protocol Coordinator {
+    func start()
+}
+
+class AppCoordinator: Coordinator {
+    func start() {
+        
+    }
+}
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    
+    private var coordinator: Coordinator?
+    
+    convenience init(coordinator: Coordinator) {
+        self.init()
+        self.coordinator = coordinator
+    }
+    
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -21,6 +39,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func configureRootViewController() {
+        coordinator?.start()
+        
+        
         let vc = WriteDownPlanUIComposer.compose(onNext: { _ in })
         
         //let vc = SetAmountUIComposer.compose(onNext: { _ in })

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -24,8 +24,17 @@ class AppCoordinator: Coordinator {
     }
     
     func start() {
-        let vc = WriteDownPlanUIComposer.compose(onNext: { _ in })
+        let vc = WriteDownPlanUIComposer
+            .compose(onNext: { [unowned self] planName in
+                pushToSetAmountScene()
+            })
+        
         navc.setViewControllers([vc], animated: false)
+    }
+    
+    private func pushToSetAmountScene() {
+        let vc = SetAmountUIComposer.compose(onNext: { _ in })
+        navc.pushViewController(vc, animated: true)
     }
 }
 

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -23,9 +23,12 @@ class AppCoordinator: Coordinator {
         self.navc = router
     }
     
+    private var savingPlan = SavingPlan(name: "", initialAmount: 0)
+    
     func start() {
         let vc = WriteDownPlanUIComposer
             .compose(onNext: { [unowned self] planName in
+                savingPlan.name = planName
                 pushToSetAmountScene()
             })
         
@@ -33,7 +36,21 @@ class AppCoordinator: Coordinator {
     }
     
     private func pushToSetAmountScene() {
-        let vc = SetAmountUIComposer.compose(onNext: { _ in })
+        let vc = SetAmountUIComposer
+            .compose(onNext: { [unowned self] planAmount in
+                savingPlan.initialAmount = planAmount.initialAmount
+                pushToSavingScene()
+            })
+        
+        navc.pushViewController(vc, animated: true)
+    }
+    
+    private func pushToSavingScene() {
+        let vc = SavingUIComposer
+            .compose(model: savingPlan, onNext: {
+                
+            })
+        
         navc.pushViewController(vc, animated: true)
     }
 }

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -12,8 +12,14 @@ protocol Coordinator {
 }
 
 class AppCoordinator: Coordinator {
+    let rootViewController: UINavigationController
+    init(rootViewController: UINavigationController) {
+        self.rootViewController = rootViewController
+    }
+    
     func start() {
-        
+        let vc = WriteDownPlanUIComposer.compose(onNext: { _ in })
+        rootViewController.setViewControllers([vc], animated: false)
     }
 }
 
@@ -21,13 +27,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     
-    private var coordinator: Coordinator?
+    private lazy var coordinator: Coordinator = {
+        let navc = UINavigationController()
+        return AppCoordinator(rootViewController: navc)
+    }()
     
     convenience init(coordinator: Coordinator) {
         self.init()
         self.coordinator = coordinator
     }
-    
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -39,18 +47,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func configureRootViewController() {
-        coordinator?.start()
-        
-        
-        let vc = WriteDownPlanUIComposer.compose(onNext: { _ in })
-        
-        //let vc = SetAmountUIComposer.compose(onNext: { _ in })
-        
-
-        window?.rootViewController = UINavigationController(rootViewController: vc)
-        
-        //let vc = SavingUIComposer.compose(model: SavingPlan(name: "Hello", initialAmount: 1), onNext: { })
-        //window?.rootViewController = vc
+        coordinator.start()
+        let root = (coordinator as? AppCoordinator)?.rootViewController
+        window?.rootViewController = root
         window?.makeKeyAndVisible()
     }
 

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -51,6 +51,7 @@ class AppCoordinator: Coordinator {
                 
             })
         
+        vc.modalPresentationStyle = .fullScreen
         navc.present(vc, animated: true, completion: nil)
     }
 }

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -25,13 +25,18 @@ class AppCoordinator: Coordinator {
     
     private var savingPlan = SavingPlan(name: "", initialAmount: 0)
     
+    private lazy var writeDownPlanViewModel: WriteDownPlanViewModel =
+    WriteDownPlanViewModel(
+        onNext: { [unowned self] planName in
+            savingPlan.name = planName
+            pushToSetAmountScene()
+        }
+    )
+    
     func start() {
         let vc = WriteDownPlanUIComposer
-            .compose(onNext: { [unowned self] planName in
-                savingPlan.name = planName
-                pushToSetAmountScene()
-            })
-        
+            .compose(viewModel: writeDownPlanViewModel)
+
         navc.setViewControllers([vc], animated: false)
     }
     
@@ -56,6 +61,7 @@ class AppCoordinator: Coordinator {
     }
     
     private func backToWriteDownPlanScene() {
+        writeDownPlanViewModel.reset()
         navc.dismiss(animated: true) { [navc] in
             navc.popToRootViewController(animated: true)
         }

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -8,18 +8,24 @@
 import UIKit
 
 protocol Coordinator {
+    var router: UIViewController { get }
     func start()
 }
 
 class AppCoordinator: Coordinator {
-    let rootViewController: UINavigationController
-    init(rootViewController: UINavigationController) {
-        self.rootViewController = rootViewController
+    var router: UIViewController {
+        return navc
+    }
+    
+    private let navc: UINavigationController
+    
+    init(router: UINavigationController) {
+        self.navc = router
     }
     
     func start() {
         let vc = WriteDownPlanUIComposer.compose(onNext: { _ in })
-        rootViewController.setViewControllers([vc], animated: false)
+        navc.setViewControllers([vc], animated: false)
     }
 }
 
@@ -29,7 +35,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private lazy var coordinator: Coordinator = {
         let navc = UINavigationController()
-        return AppCoordinator(rootViewController: navc)
+        return AppCoordinator(router: navc)
     }()
     
     convenience init(coordinator: Coordinator) {
@@ -48,8 +54,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func configureRootViewController() {
         coordinator.start()
-        let root = (coordinator as? AppCoordinator)?.rootViewController
-        window?.rootViewController = root
+        window?.rootViewController = coordinator.router
         window?.makeKeyAndVisible()
     }
 

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -7,67 +7,6 @@
 
 import UIKit
 
-protocol Coordinator {
-    var router: UIViewController { get }
-    func start()
-}
-
-class AppCoordinator: Coordinator {
-    var router: UIViewController {
-        return navc
-    }
-    
-    private let navc: UINavigationController
-    
-    init(router: UINavigationController) {
-        self.navc = router
-    }
-    
-    private var savingPlan = SavingPlan(name: "", initialAmount: 0)
-    
-    private lazy var writeDownPlanViewModel: WriteDownPlanViewModel =
-    WriteDownPlanViewModel(
-        onNext: { [unowned self] planName in
-            savingPlan.name = planName
-            pushToSetAmountScene()
-        }
-    )
-    
-    func start() {
-        let vc = WriteDownPlanUIComposer
-            .compose(viewModel: writeDownPlanViewModel)
-
-        navc.setViewControllers([vc], animated: false)
-    }
-    
-    private func pushToSetAmountScene() {
-        let vc = SetAmountUIComposer
-            .compose(onNext: { [unowned self] planAmount in
-                savingPlan.initialAmount = planAmount.initialAmount
-                pushToSavingScene()
-            })
-        
-        navc.pushViewController(vc, animated: true)
-    }
-    
-    private func pushToSavingScene() {
-        let vc = SavingUIComposer
-            .compose(model: savingPlan, onNext: { [unowned self] in
-                backToWriteDownPlanScene()
-            })
-        
-        vc.modalPresentationStyle = .fullScreen
-        navc.present(vc, animated: true, completion: nil)
-    }
-    
-    private func backToWriteDownPlanScene() {
-        writeDownPlanViewModel.reset()
-        navc.dismiss(animated: true) { [navc] in
-            navc.popToRootViewController(animated: true)
-        }
-    }
-}
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?

--- a/SavingMoney/SceneDelegate.swift
+++ b/SavingMoney/SceneDelegate.swift
@@ -47,12 +47,18 @@ class AppCoordinator: Coordinator {
     
     private func pushToSavingScene() {
         let vc = SavingUIComposer
-            .compose(model: savingPlan, onNext: {
-                
+            .compose(model: savingPlan, onNext: { [unowned self] in
+                backToWriteDownPlanScene()
             })
         
         vc.modalPresentationStyle = .fullScreen
         navc.present(vc, animated: true, completion: nil)
+    }
+    
+    private func backToWriteDownPlanScene() {
+        navc.dismiss(animated: true) { [navc] in
+            navc.popToRootViewController(animated: true)
+        }
     }
 }
 

--- a/SavingMoney/SetAmount/ViewController/SetAmountViewController.swift
+++ b/SavingMoney/SetAmount/ViewController/SetAmountViewController.swift
@@ -49,4 +49,10 @@ public class SetAmountViewController: UIViewController {
     @IBAction func deleteBtnTouchUpInside(_ sender: Any) {
         viewModel?.deleteBackward()
     }
+    
+    @IBAction func nextBarBtnTapped(_ sender: Any) {
+        viewModel?.nextStep()
+    }
+    
+    
 }

--- a/SavingMoney/WritePlan/ViewController/WriteDownPlanViewController.swift
+++ b/SavingMoney/WritePlan/ViewController/WriteDownPlanViewController.swift
@@ -47,6 +47,11 @@ public class WriteDownPlanViewController: UIViewController {
             for: .editingChanged
         )
         
+        viewModel?.onPlanModelChanged = { planModel in
+            textField.text = planModel
+            
+        }
+        
         barBtnItem.target = self
         barBtnItem.action = #selector(nextBarBtnItemTapped(_:))
     }

--- a/SavingMoney/WritePlan/ViewModel/WriteDownPlanViewModel.swift
+++ b/SavingMoney/WritePlan/ViewModel/WriteDownPlanViewModel.swift
@@ -6,14 +6,17 @@
 //
 
 import Foundation
-class WriteDownPlanViewModel {
+public class WriteDownPlanViewModel {
     var onNextStateChange: ((Bool) -> Void)?
+    
+    
+    var onPlanModelChanged: ((PlanModel) -> Void)?
     
     private var planModel: PlanModel
     
     private let onNext: (PlanModel) -> Void
     
-    init(planModel: PlanModel = "", onNext: @escaping (PlanModel) -> Void) {
+    public init(planModel: PlanModel = "", onNext: @escaping (PlanModel) -> Void) {
         self.planModel = planModel
         self.onNext = onNext
     }
@@ -31,6 +34,12 @@ class WriteDownPlanViewModel {
     
     func nextStep() {
         onNext(planModel)
+    }
+    
+    func reset() {
+        planModel = ""
+        onPlanModelChanged?(planModel)
+        onNextStateChange?(false)
     }
     
     

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -9,27 +9,27 @@ import XCTest
 @testable import SavingMoney
 
 class AppCoordinatorTests: XCTestCase {
-    func test_start_setWriteDownPlanSceneOnNavigationStackRoot() {
-        let (sut, router) = makeSUT()
-        
-        sut.start()
-        
-        XCTAssertTrue(router.viewControllers.first is WriteDownPlanViewController)
-    }
-    
-    func test_pushSetAmountSceneOnTop_onWriteDownPlanNext() {
+    func test_navigation() {
         let (sut, router) = makeSUT()
         
         sut.start()
         let writeDownPlan = router.topViewController as? WriteDownPlanViewController
         writeDownPlan?.loadViewIfNeeded()
-        XCTAssertNotNil(writeDownPlan)
+        XCTAssertNotNil(writeDownPlan, "First Scene is WriteDownPlan Scene")
         
         writeDownPlan?.simulateTapNext()
         router.view.forceLayout()
         
         let setAmount = router.topViewController as? SetAmountViewController
-        XCTAssertNotNil(setAmount)
+        setAmount?.loadViewIfNeeded()
+        XCTAssertNotNil(setAmount, "Tap next route to SetAmount Scene")
+        
+        setAmount?.simulateTapNext()
+        router.view.forceLayout()
+        
+        let saving = router.topViewController as? SavingViewController
+        saving?.loadViewIfNeeded()
+        XCTAssertNotNil(saving, "Tap next again route to Saving Scene")
     }
     
     private func makeSUT() -> (AppCoordinator, RouterSpy) {

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -19,7 +19,7 @@ class AppCoordinatorTests: XCTestCase {
     
     private func makeSUT() -> (AppCoordinator, NavigationSpy) {
         let navcSpy = NavigationSpy()
-        let sut = AppCoordinator(rootViewController: navcSpy)
+        let sut = AppCoordinator(router: navcSpy)
         return (sut, navcSpy)
         
     }

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -19,7 +19,10 @@ class AppCoordinatorTests: XCTestCase {
         let setAmount = assertPushedTop(is: SetAmountViewController.self, on: router)
     
         setAmount?.simulateTapNext()
-        assertPresentedTop(is: SavingViewController.self, on: router)
+        let saving = assertPresentedTop(is: SavingViewController.self, on: router)
+        
+        saving?.simulatePressReStart()
+        assertPushedTop(is: WriteDownPlanViewController.self, on: router)
     }
     
     @discardableResult
@@ -64,13 +67,23 @@ private class RouterSpy: UINavigationController {
     }
     
     override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
-        //super.setViewControllers(viewControllers, animated: animated)
         guard let first = viewControllers.first else { return }
         pushedViewControllers.append(first)
+        super.setViewControllers(viewControllers, animated: animated)
     }
     
     var presentedViewControllers: [UIViewController] = []
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentedViewControllers.append(viewControllerToPresent)
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        presentedViewControllers.removeLast()
+        super.dismiss(animated: flag, completion: completion)
+    }
+    
+    override func popToRootViewController(animated: Bool) -> [UIViewController]? {
+        pushedViewControllers.removeLast(pushedViewControllers.count - 1)
+        return super.popToRootViewController(animated: animated)
     }
 }

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -38,11 +38,14 @@ class AppCoordinatorTests: XCTestCase {
     private func assertPresentedTop<ViewController: UIViewController>(
         is type: ViewController.Type,
         on router: RouterSpy,
+        with style: UIModalPresentationStyle = .fullScreen,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> ViewController? {
         let top = router.presentedViewControllers.last as? ViewController
         XCTAssertNotNil(top, "expect an instance of \(type) but got \(String(describing: router.pushedViewControllers.last))", file: file, line: line)
+        
+        XCTAssertTrue(top?.modalPresentationStyle == style, "expect modal presentation style: \(style), but got \(String(describing: top?.modalPresentationStyle)) instead", file: file, line: line)
         return top
     }
     

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -15,6 +15,7 @@ class AppCoordinatorTests: XCTestCase {
         sut.start()
         let writeDownPlan = assertPushedTop(is: WriteDownPlanViewController.self, on: router)
         
+        writeDownPlan?.simulateTypingPlanName("My Awesome Saving Plan")
         writeDownPlan?.simulateTapNext()
         let setAmount = assertPushedTop(is: SetAmountViewController.self, on: router)
     
@@ -23,6 +24,7 @@ class AppCoordinatorTests: XCTestCase {
         
         saving?.simulatePressReStart()
         assertPushedTop(is: WriteDownPlanViewController.self, on: router)
+        XCTAssertNilOrEmptyString(writeDownPlan?.planName, "should have no plan name when pop to write down plan scene")
     }
     
     @discardableResult

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -17,6 +17,21 @@ class AppCoordinatorTests: XCTestCase {
         XCTAssertTrue(router.viewControllers.first is WriteDownPlanViewController)
     }
     
+    func test_pushSetAmountSceneOnTop_onWriteDownPlanNext() {
+        let (sut, router) = makeSUT()
+        
+        sut.start()
+        let writeDownPlan = router.topViewController as? WriteDownPlanViewController
+        writeDownPlan?.loadViewIfNeeded()
+        XCTAssertNotNil(writeDownPlan)
+        
+        writeDownPlan?.simulateTapNext()
+        router.view.forceLayout()
+        
+        let setAmount = router.topViewController as? SetAmountViewController
+        XCTAssertNotNil(setAmount)
+    }
+    
     private func makeSUT() -> (AppCoordinator, RouterSpy) {
         let routerSpy = RouterSpy()
         let sut = AppCoordinator(router: routerSpy)

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -10,21 +10,21 @@ import XCTest
 
 class AppCoordinatorTests: XCTestCase {
     func test_start_setWriteDownPlanSceneOnNavigationStackRoot() {
-        let (sut, navigationController) = makeSUT()
+        let (sut, router) = makeSUT()
         
         sut.start()
         
-        XCTAssertTrue(navigationController.viewControllers.first is WriteDownPlanViewController)
+        XCTAssertTrue(router.viewControllers.first is WriteDownPlanViewController)
     }
     
-    private func makeSUT() -> (AppCoordinator, NavigationSpy) {
-        let navcSpy = NavigationSpy()
-        let sut = AppCoordinator(router: navcSpy)
-        return (sut, navcSpy)
+    private func makeSUT() -> (AppCoordinator, RouterSpy) {
+        let routerSpy = RouterSpy()
+        let sut = AppCoordinator(router: routerSpy)
+        return (sut, routerSpy)
         
     }
 }
 
-private class NavigationSpy: UINavigationController {
+private class RouterSpy: UINavigationController {
     
 }

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -13,23 +13,26 @@ class AppCoordinatorTests: XCTestCase {
         let (sut, router) = makeSUT()
         
         sut.start()
-        let writeDownPlan = router.topViewController as? WriteDownPlanViewController
-        writeDownPlan?.loadViewIfNeeded()
-        XCTAssertNotNil(writeDownPlan, "First Scene is WriteDownPlan Scene")
+        let writeDownPlan = assertTop(is: WriteDownPlanViewController.self, on: router)
         
         writeDownPlan?.simulateTapNext()
-        router.view.forceLayout()
-        
-        let setAmount = router.topViewController as? SetAmountViewController
-        setAmount?.loadViewIfNeeded()
-        XCTAssertNotNil(setAmount, "Tap next route to SetAmount Scene")
-        
+        let setAmount = assertTop(is: SetAmountViewController.self, on: router)
+    
         setAmount?.simulateTapNext()
-        router.view.forceLayout()
-        
-        let saving = router.topViewController as? SavingViewController
-        saving?.loadViewIfNeeded()
-        XCTAssertNotNil(saving, "Tap next again route to Saving Scene")
+        assertTop(is: SavingViewController.self, on: router)
+    }
+    
+    @discardableResult
+    private func assertTop<ViewController: UIViewController>(
+        is type: ViewController.Type,
+        on router: UINavigationController,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ViewController? {
+        let top = router.topViewController as? ViewController
+        top?.loadViewIfNeeded()
+        XCTAssertNotNil(top, file: file, line: line)
+        return top
     }
     
     private func makeSUT() -> (AppCoordinator, RouterSpy) {
@@ -40,6 +43,4 @@ class AppCoordinatorTests: XCTestCase {
     }
 }
 
-private class RouterSpy: UINavigationController {
-    
-}
+private class RouterSpy: UINavigationController {}

--- a/SavingMoneyTests/AppCoordinatorTests.swift
+++ b/SavingMoneyTests/AppCoordinatorTests.swift
@@ -1,0 +1,30 @@
+//
+//  AppCoordinatorTests.swift
+//  SavingMoneyTests
+//
+//  Created by Paul Lee on 2021/12/21.
+//
+
+import XCTest
+@testable import SavingMoney
+
+class AppCoordinatorTests: XCTestCase {
+    func test_start_setWriteDownPlanSceneOnNavigationStackRoot() {
+        let (sut, navigationController) = makeSUT()
+        
+        sut.start()
+        
+        XCTAssertTrue(navigationController.viewControllers.first is WriteDownPlanViewController)
+    }
+    
+    private func makeSUT() -> (AppCoordinator, NavigationSpy) {
+        let navcSpy = NavigationSpy()
+        let sut = AppCoordinator(rootViewController: navcSpy)
+        return (sut, navcSpy)
+        
+    }
+}
+
+private class NavigationSpy: UINavigationController {
+    
+}

--- a/SavingMoneyTests/SavingMoneyViewControllerTests.swift
+++ b/SavingMoneyTests/SavingMoneyViewControllerTests.swift
@@ -195,6 +195,7 @@ extension SavingViewController {
     }
     
     func simulatePressReStart() {
+        loadViewIfNeeded()
         guard let action = titleBarController.restartBarBtnItem.action else { return }
         UIApplication.shared.sendAction(action, to: titleBarController.restartBarBtnItem.target, from: nil, for: nil)
     }

--- a/SavingMoneyTests/SceneDelegateTests.swift
+++ b/SavingMoneyTests/SceneDelegateTests.swift
@@ -40,6 +40,8 @@ class SceneDelegateTests: XCTestCase {
 }
 
 private class CoordinatorSpy: Coordinator {
+    var router: UIViewController = UIViewController()
+    
     var startCallCount = 0
     func start() {
         startCallCount += 1

--- a/SavingMoneyTests/SceneDelegateTests.swift
+++ b/SavingMoneyTests/SceneDelegateTests.swift
@@ -11,8 +11,7 @@ import XCTest
 class SceneDelegateTests: XCTestCase {
 
     func test_sceneWillConnectToSession_configureRootViewController() {
-        let sut = SceneDelegate()
-        sut.window = UIWindow()
+        let (sut, _) = makeSUT()
         
         sut.configureRootViewController()
         
@@ -22,5 +21,27 @@ class SceneDelegateTests: XCTestCase {
         let top = root?.topViewController as? WriteDownPlanViewController
         XCTAssertNotNil(top, "Expected `WriteDownPlanViewController` as root of `UINavigationController`, got \(String(describing: top)) instead")
     }
+    
+    func test_sceneWillConnectToSession_messageAppCoordinatorStart() {
+        let (sut, coordinator) = makeSUT()
+        
+        sut.configureRootViewController()
+        
+        XCTAssertEqual(coordinator.startCallCount, 1)
+    }
+    
+    private func makeSUT() -> (SceneDelegate, CoordinatorSpy) {
+        let coordinator = CoordinatorSpy()
+        let sut = SceneDelegate(coordinator: coordinator)
+        sut.window = UIWindow()
+        return (sut, coordinator)
+    }
 
+}
+
+private class CoordinatorSpy: Coordinator {
+    var startCallCount = 0
+    func start() {
+        startCallCount += 1
+    }
 }

--- a/SavingMoneyTests/SceneDelegateTests.swift
+++ b/SavingMoneyTests/SceneDelegateTests.swift
@@ -11,7 +11,8 @@ import XCTest
 class SceneDelegateTests: XCTestCase {
 
     func test_sceneWillConnectToSession_configureRootViewController() {
-        let (sut, _) = makeSUT()
+        let sut = SceneDelegate()
+        sut.window = UIWindow()
         
         sut.configureRootViewController()
         
@@ -24,7 +25,7 @@ class SceneDelegateTests: XCTestCase {
     
     func test_sceneWillConnectToSession_messageAppCoordinatorStart() {
         let (sut, coordinator) = makeSUT()
-        
+        sut.window = UIWindow()
         sut.configureRootViewController()
         
         XCTAssertEqual(coordinator.startCallCount, 1)
@@ -33,7 +34,6 @@ class SceneDelegateTests: XCTestCase {
     private func makeSUT() -> (SceneDelegate, CoordinatorSpy) {
         let coordinator = CoordinatorSpy()
         let sut = SceneDelegate(coordinator: coordinator)
-        sut.window = UIWindow()
         return (sut, coordinator)
     }
 

--- a/SavingMoneyTests/SetAmountViewControllerTests.swift
+++ b/SavingMoneyTests/SetAmountViewControllerTests.swift
@@ -83,9 +83,9 @@ extension SetAmountViewController {
     }
     
     func simulateTapNext() {
+        loadViewIfNeeded()
         guard let action = nextBarBtnItem.action else { return }
         UIApplication.shared.sendAction(action, to: nextBarBtnItem.target, from: nil, for: nil)
-        navigationController?.view.forceLayout()
     }
     
 }

--- a/SavingMoneyTests/SetAmountViewControllerTests.swift
+++ b/SavingMoneyTests/SetAmountViewControllerTests.swift
@@ -85,6 +85,7 @@ extension SetAmountViewController {
     func simulateTapNext() {
         guard let action = nextBarBtnItem.action else { return }
         UIApplication.shared.sendAction(action, to: nextBarBtnItem.target, from: nil, for: nil)
+        navigationController?.view.forceLayout()
     }
     
 }

--- a/SavingMoneyTests/SetAmountViewControllerTests.swift
+++ b/SavingMoneyTests/SetAmountViewControllerTests.swift
@@ -82,4 +82,9 @@ extension SetAmountViewController {
         nextBarBtnItem.isEnabled
     }
     
+    func simulateTapNext() {
+        guard let action = nextBarBtnItem.action else { return }
+        UIApplication.shared.sendAction(action, to: nextBarBtnItem.target, from: nil, for: nil)
+    }
+    
 }

--- a/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
+++ b/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
@@ -120,6 +120,7 @@ extension WriteDownPlanViewController {
     func simulateTapNext() {
         guard let action = nextBarBtnItem.action else { return }
         UIApplication.shared.sendAction(action, to: nextBarBtnItem.target, from: nil, for: nil)
+        navigationController?.view.forceLayout()
     }
     
     @discardableResult

--- a/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
+++ b/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
@@ -59,7 +59,8 @@ class WriteDownPlanViewControllerTests: XCTestCase {
     }
     
     private func makeSUT(onNext: @escaping ((PlanModel) -> Void) = { _ in }) -> WriteDownPlanViewController {
-        return WriteDownPlanUIComposer.compose(onNext: onNext)
+        return WriteDownPlanUIComposer
+            .compose(viewModel: WriteDownPlanViewModel(onNext: onNext))
     }
     
     private func assertThat(_ sut: WriteDownPlanViewController, render view: UIView, onWillShow keyboardView: UIView, spacing: CGFloat, file: StaticString = #filePath, line: UInt = #line) {
@@ -102,6 +103,7 @@ extension WriteDownPlanViewController {
     }
     
     func simulateTypingPlanName(_ name: String) {
+        loadViewIfNeeded()
         planTextField.text = name
         planTextField.sendActions(for: .editingChanged)
     }

--- a/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
+++ b/SavingMoneyTests/WriteDownPlanViewControllerTests.swift
@@ -118,9 +118,9 @@ extension WriteDownPlanViewController {
     }
     
     func simulateTapNext() {
+        loadViewIfNeeded()
         guard let action = nextBarBtnItem.action else { return }
         UIApplication.shared.sendAction(action, to: nextBarBtnItem.target, from: nil, for: nil)
-        navigationController?.view.forceLayout()
     }
     
     @discardableResult


### PR DESCRIPTION
- scene will connect to session message `AppCoordinator` to start
- `AppCoordinator` set `WriteDownPlanViewController` as root viewController of navigation stack
- expose `router` in `Coordinator` protocol to prevent force casting `Coordinator` to `AppCoordinator`
- rename variables in `AppCoordinatorTests`
- navigation from writeDownPlan scene to setAmountScene
- group temporal coupled test case as a single test case to represent a story
- add helper to simplify test case
- present `SavingViewController` on tap next bar button item on `SetAmountViewController`
- assert full screen modalPresentationStyle for `SavingViewController`
- back to write down plan scene on tap restart
- clear `planName` text filed on pop back to `WriteDownPlanViewController`
- move coordinator into a separate file
